### PR TITLE
Match HTTP::Response params and return the output of the route

### DIFF
--- a/src/frank/handler.cr
+++ b/src/frank/handler.cr
@@ -26,10 +26,12 @@ class Frank::Handler < HTTP::Handler
         begin
           body = route.handler.call(context).to_s
           content_type = context.response?.try(&.content_type) || "text/plain"
-          return HTTP::Response.new(200, body)
+          return HTTP::Response.ok(content_type, body)
         rescue ex
-          return HTTP::Response.new(500, "Internal Server Error", {"Content-Type" => "text/plain"}, ex.to_s)
+          return HTTP::Response.error("text/plain", "Internal Server Error:\n #{ex.to_s}")
         end
+      else
+        return HTTP::Response.not_found
       end
     end
     nil

--- a/src/frank/handler.cr
+++ b/src/frank/handler.cr
@@ -26,9 +26,9 @@ class Frank::Handler < HTTP::Handler
         begin
           body = route.handler.call(context).to_s
           content_type = context.response?.try(&.content_type) || "text/plain"
-          return HTTP::Response.new("HTTP/1.1", 200, "OK", {"Content-Type" => content_type}, body)
+          return HTTP::Response.new(200, body, {"Content-Type" => content_type}, body)
         rescue ex
-          return HTTP::Response.new("HTTP/1.1", 500, "Internal Server Error", {"Content-Type" => "text/plain"}, ex.to_s)
+          return HTTP::Response.new(500, "Internal Server Error", {"Content-Type" => "text/plain"}, ex.to_s)
         end
       end
     end

--- a/src/frank/handler.cr
+++ b/src/frank/handler.cr
@@ -26,7 +26,7 @@ class Frank::Handler < HTTP::Handler
         begin
           body = route.handler.call(context).to_s
           content_type = context.response?.try(&.content_type) || "text/plain"
-          return HTTP::Response.new(200, body, {"Content-Type" => content_type}, body)
+          return HTTP::Response.new(200, body)
         rescue ex
           return HTTP::Response.new(500, "Internal Server Error", {"Content-Type" => "text/plain"}, ex.to_s)
         end


### PR DESCRIPTION
It seems the params of HTTP::Response#new have changed, and frank hasn't been updated. By removing the protocol header argument in the method call (which matches the HTTP lib), frank compiles and runs.

I also made a change that allows the body to return the output of the route, rather than a hardcoded "OK".

Edit:
The second commit fixes an error where there are two response bodies returned.
