### PR TITLE
Move static file handler to be called after the instance handler

### DIFF
--- a/spec/frank_handler_spec.cr
+++ b/spec/frank_handler_spec.cr
@@ -1,4 +1,4 @@
-require "spec_helper"
+require "./spec_helper"
 
 describe "Frank::Handler" do
   it "routes" do

--- a/spec/route_spec.cr
+++ b/spec/route_spec.cr
@@ -1,4 +1,4 @@
-require "spec_helper"
+require "./spec_helper"
 
 describe "Route" do
   describe "match" do

--- a/src/frank.cr
+++ b/src/frank.cr
@@ -11,8 +11,8 @@ at_exit do
   config = Frank.config
   handlers = [] of HTTP::Handler
   handlers << HTTP::LogHandler.new
-  handlers << HTTP::StaticFileHandler.new("./public")
   handlers << Frank::Handler::INSTANCE
+  handlers << HTTP::StaticFileHandler.new("./public")
   server = HTTP::Server.new(config.port, handlers)
 
   server.ssl = config.ssl


### PR DESCRIPTION
This way only routes that are not caught by the instance handler will go
through to the static file handler.
