### PR TITLE
Update Frank for Crystal 0.9.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
-# frank
+# Frank
 
 This is a proof-of-concept [Sinatra](http://www.sinatrarb.com/) clone for [Crystal](http://www.crystal-lang.org).
+
+## Getting Started
+
+1. If you haven't already, [install Crystal](http://crystal-lang.org/docs/installation/index.html)
+2. Clone the repository (`$ git@github.com:manastech/frank.git`)
+3. Start Frank (`$ cd frank && crystal samples/hello_world.cr`)
+4. Check out your app on http://localhost:3000/
 
 ## Status
 

--- a/src/frank/handler.cr
+++ b/src/frank/handler.cr
@@ -1,5 +1,5 @@
 require "http/server"
-require "cgi"
+require "http/params"
 
 class Frank::Handler < HTTP::Handler
   INSTANCE = new
@@ -18,13 +18,12 @@ class Frank::Handler < HTTP::Handler
   end
 
   def exec_request(request)
-    uri = request.uri
-    components = uri.path.not_nil!.split "/"
+    components = request.path.not_nil!.split "/"
     @routes.each do |route|
       params = route.match(request.method, components)
       if params
-        if query = uri.query
-          CGI.parse(query) do |key, value|
+        if query = request.query
+          HTTP::Params.parse(query) do |key, value|
             params[key] ||= value
           end
         end

--- a/src/frank/route.cr
+++ b/src/frank/route.cr
@@ -7,7 +7,7 @@ class Frank::Route
 
   def match(method, components)
     return nil unless method == @method
-    return nil unless components.length == @components.length
+    return nil unless components.size == @components.size
 
     params = nil
 


### PR DESCRIPTION
Following [the dismantling of CGI](https://github.com/manastech/crystal/pull/1548), Frank needs a couple of updates to work properly again. Those are:
- Update `src/frank/handler.cr` to use the new `HTTP::Params` namespace and not rely on the (now private) `uri` method;
- Update the arrays in `src/frank/route.cr` to use `Array#size` instead of `#length` (the latter was throwing an `undefined method 'length'` error)

This PR also augments the `README` with instructions for running the sample app.
